### PR TITLE
feat(frontend): add Tasks tab with dummy data and grouped repeaters

### DIFF
--- a/apps/frontend/src/components/TasksTab.tsx
+++ b/apps/frontend/src/components/TasksTab.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { tasks } from '../data/tasks';
+import { groupTasks } from '../utils/groupTasks';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
+const Section: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => (
+  <div className="mb-6">
+    <h2 className="text-xl font-semibold mb-2">{title}</h2>
+    <div className="space-y-2">{children}</div>
+  </div>
+);
+
+const TaskRow: React.FC<{ task: any }> = ({ task }) => (
+  <Card className="rounded-2xl shadow p-3 flex items-center justify-between">
+    <CardContent className="flex-1 grid grid-cols-6 gap-2 items-center">
+      <span className="col-span-2 font-medium">{task.title}</span>
+      <span className="col-span-2 text-sm text-gray-600">{task.description}</span>
+      <span className="text-sm">{new Date(task.dueDate).toLocaleDateString()}</span>
+      <span className="capitalize text-xs px-2 py-1 rounded bg-gray-100">{task.priority}</span>
+    </CardContent>
+    <Button size="sm">Complete</Button>
+  </Card>
+);
+
+const TasksTab: React.FC = () => {
+  const grouped = groupTasks(tasks);
+
+  return (
+    <div className="p-4">
+      <Section title="Today">
+        {grouped.today.map(task => <TaskRow key={task.id} task={task} />)}
+      </Section>
+      <Section title="Tomorrow">
+        {grouped.tomorrow.map(task => <TaskRow key={task.id} task={task} />)}
+      </Section>
+      <Section title="This Week">
+        {grouped.thisWeek.map(task => <TaskRow key={task.id} task={task} />)}
+      </Section>
+      <Section title="Later">
+        {grouped.later.map(task => <TaskRow key={task.id} task={task} />)}
+      </Section>
+    </div>
+  );
+};
+
+export default TasksTab;

--- a/apps/frontend/src/data/tasks.ts
+++ b/apps/frontend/src/data/tasks.ts
@@ -1,0 +1,43 @@
+export type Task = {
+  id: string;
+  title: string;
+  description: string;
+  dueDate: string; // ISO date
+  status: 'todo' | 'in_progress' | 'done';
+  priority: 'low' | 'medium' | 'high';
+  people: string[]; // placeholder: user initials
+  type: 'dashboard' | 'mobile' | 'web';
+};
+
+export const tasks: Task[] = [
+  {
+    id: '1',
+    title: 'Employee Details',
+    description: 'Create a page where there is information about employees',
+    dueDate: new Date().toISOString(),
+    status: 'todo',
+    priority: 'high',
+    people: ['AB'],
+    type: 'dashboard',
+  },
+  {
+    id: '2',
+    title: 'Darkmode version',
+    description: 'Darkmode version for all screens',
+    dueDate: new Date(Date.now() + 86400000).toISOString(),
+    status: 'in_progress',
+    priority: 'medium',
+    people: ['CD','EF'],
+    type: 'mobile',
+  },
+  {
+    id: '3',
+    title: 'Super Admin Role',
+    description: 'Add super admin role with permissions',
+    dueDate: new Date(Date.now() + 2*86400000).toISOString(),
+    status: 'todo',
+    priority: 'low',
+    people: ['GH'],
+    type: 'web',
+  }
+];

--- a/apps/frontend/src/utils/groupTasks.ts
+++ b/apps/frontend/src/utils/groupTasks.ts
@@ -1,0 +1,28 @@
+import { Task } from '../data/tasks';
+
+export type GroupedTasks = {
+  today: Task[];
+  tomorrow: Task[];
+  thisWeek: Task[];
+  later: Task[];
+};
+
+export function groupTasks(tasks: Task[]): GroupedTasks {
+  const now = new Date();
+  const today = tasks.filter(t => new Date(t.dueDate).toDateString() === now.toDateString());
+
+  const tomorrowDate = new Date(now);
+  tomorrowDate.setDate(now.getDate() + 1);
+  const tomorrow = tasks.filter(t => new Date(t.dueDate).toDateString() === tomorrowDate.toDateString());
+
+  const weekEnd = new Date(now);
+  weekEnd.setDate(now.getDate() + (7 - now.getDay()));
+  const thisWeek = tasks.filter(t => {
+    const d = new Date(t.dueDate);
+    return d > tomorrowDate && d <= weekEnd;
+  });
+
+  const later = tasks.filter(t => !today.includes(t) && !tomorrow.includes(t) && !thisWeek.includes(t));
+
+  return { today, tomorrow, thisWeek, later };
+}


### PR DESCRIPTION
This PR introduces the new **Tasks tab** using dummy data.

### Changes
- Added `tasks.ts` with initial dummy tasks.
- Implemented `groupTasks` util to bucket tasks into Today, Tomorrow, This Week, Later.
- Built `TasksTab.tsx` component with repeaters for each group.
- Styled rows with task info, priority badge, and complete button.

### Next Steps
- Hook into backend actions (move/complete/undo).
- Replace dummy avatars with actual user data.
- Enhance list view with filtering & sorting.