### PR TITLE
Fix frontend config for Vite (tsconfig + package.json)

### DIFF
--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "./tsconfig.node.json" }
+  ]
+}


### PR DESCRIPTION
This PR fixes the frontend local dev issues:

- Added missing `tsconfig.node.json` with minimal Node config for Vite.
- Updated `tsconfig.json` with correct compiler options and alias paths.
- Updated `package.json` to include `"type": "module"` to silence PostCSS warning.

After merging, run:
```bash
cd apps/frontend
rm -rf node_modules package-lock.json
npm install
npm run dev
```
This should start Vite cleanly without config errors.