### PR TITLE
Fix frontend package.json

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,1 +1,23 @@
-.*
+{
+  "name": "holly-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.18",
+    "postcss": "^8.4.35",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.3.3",
+    "vite": "^4.5.0"
+  }
+}


### PR DESCRIPTION
This PR restores a valid `apps/frontend/package.json`, replacing the corrupted version that only contained `.*`. This fixes local and CI npm install issues.