### PR TITLE
Fix missing InboxTab, ProjectsTab, and CalendarTab components

### DIFF
--- a/apps/frontend/src/components/CalendarTab.tsx
+++ b/apps/frontend/src/components/CalendarTab.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export default function CalendarTab() {
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-bold mb-2">Calendar</h2>
+      <p>View your tasks and events on the calendar.</p>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/InboxTab.tsx
+++ b/apps/frontend/src/components/InboxTab.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export default function InboxTab() {
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-bold mb-2">Inbox</h2>
+      <p>Your captured tasks will appear here.</p>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/ProjectsTab.tsx
+++ b/apps/frontend/src/components/ProjectsTab.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export default function ProjectsTab() {
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-bold mb-2">Projects</h2>
+      <p>Manage your projects here.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR adds placeholder React components for InboxTab, ProjectsTab, and CalendarTab, which were referenced in `App.tsx` but missing from the repo. This resolves local Vite dev server import errors.