### PR TITLE
Cleanup repo: ignore caches and remove tracked clutter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+
+# Ignore caches
+__pycache__/
+apps/frontend/node_modules/
+apps/frontend/.vite/
+.DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: debug-statements
+      - id: detect-private-key
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+      - id: check-executables-have-shebangs
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.0.0
+    hooks:
+      - id: prettier
+        additional_dependencies: ["prettier@3.0.0"]
+
+  - repo: local
+    hooks:
+      - id: check-ignored-files
+        name: Check ignored files are not committed
+        entry: bash -c 'git ls-files -ci --exclude-standard | grep . && (echo "Error: Ignored files were committed" && exit 1) || exit 0'
+        language: system
+        types: [file]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 # Holly v6
 
 This is the starting repo scaffold for Holly AI v6.
+
+## Development Setup
+
+### Pre-commit hooks
+This repo uses [pre-commit](https://pre-commit.com/) to enforce code hygiene and prevent committing ignored files.
+
+To set up locally:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Now hooks will run automatically on `git commit`. To manually run on all files:
+
+```bash
+pre-commit run --all-files
+```


### PR DESCRIPTION
This PR cleans up the repository by:

- Removing tracked cache and OS build artifacts (`__pycache__`, `.DS_Store`, vite deps)
- Adding proper ignore rules in `.gitignore` so these files are not tracked again

This ensures the repo stays clean and only source code/config files are tracked.