### PR TITLE
fix(frontend): use index.global.css for FullCalendar v6

### DIFF
--- a/apps/frontend/src/tabs/TabCalendar.tsx
+++ b/apps/frontend/src/tabs/TabCalendar.tsx
@@ -4,7 +4,7 @@ import interactionPlugin from "@fullcalendar/interaction";
 import { Box } from "@mui/material";
 
 // ✅ Fixed import for FullCalendar v6
-import "@fullcalendar/daygrid/index.css";
+import "@fullcalendar/daygrid/index.global.css";
 
 export default function TabCalendar() {
   return (


### PR DESCRIPTION
- Updated TabCalendar.tsx to import @fullcalendar/daygrid/index.global.css instead of index.css
- Fixes Vite dependency scan error when running dev server